### PR TITLE
Release/0.7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,27 @@ language: scala
 
 scala:
  - "2.10.4"
+ - "2.11.5"
 
 # Emails to notify
 notifications:
   slack:
-    - newzly:nfmIGqhmrfJb6pIH6I50mnCO
     - websudos:P9QNXx1ZGFnDHp3v3jUqtB8k
   email:
     - dev@websudos.co.uk
+jdk:
+  - oraclejdk7
+  - openjdk7
 
-# Branches to build.
-branches:
-  only:
-    - master
-    - develop
+cache:
+  directories:
+    - $HOME/.ivy2/cache
 
+before_script: travis_retry sbt ++$TRAVIS_SCALA_VERSION update
+
+script:
+  - sbt clean coverage test &&
+    sbt coverageAggregate
+
+after_success:
+  - sbt coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# util[![Build Status](https://travis-ci.org/websudos/util.svg?branch=develop)](https://travis-ci.org/websudos/util)
+# util[![Build Status](https://travis-ci.org/websudos/util.svg?branch=develop)](https://travis-ci.org/websudos/util) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.websudos/util_2.10/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.util/util_2.10)
 
 The latest available version of the util library is ```val UtilVersion = 0.7.0```. This library is only deployed to our managed Maven repository,
 available at ```http://maven.websudos.co.uk```. It is publicly available, for both Scala 2.10.x and Scala 2.11.x.

--- a/project/UtilBuild.scala
+++ b/project/UtilBuild.scala
@@ -48,9 +48,9 @@ object UtilBuild extends Build {
 
   val publishUrl = "http://maven.websudos.co.uk"
 
-  val publishSettings : Seq[Def.Setting[_]] = Seq(
+  val mvnpublishSettings : Seq[Def.Setting[_]] = Seq(
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
-    crossScalaVersions := Seq("2.10.4", "2.11.5"),
+    crossScalaVersions := Seq("2.10.5", "2.11.5"),
     publishTo <<= version { (v: String) => {
       if (v.trim.endsWith("SNAPSHOT"))
         Some("snapshots" at publishUrl + "/ext-snapshot-local")
@@ -63,7 +63,7 @@ object UtilBuild extends Build {
     pomIncludeRepository := { _ => true }
   )
 
-  val mavenPublishSettings : Seq[Def.Setting[_]] = Seq(
+  val publishSettings : Seq[Def.Setting[_]] = Seq(
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
     publishMavenStyle := true,
     publishTo <<= version.apply {
@@ -91,7 +91,7 @@ object UtilBuild extends Build {
         </scm>
         <developers>
           <developer>
-            <id>alexflav</id>
+            <id>alexflav23</id>
             <name>Flavian Alexandru</name>
             <url>http://github.com/alexflav23</url>
           </developer>
@@ -100,8 +100,8 @@ object UtilBuild extends Build {
 
   val sharedSettings: Seq[Def.Setting[_]] = Seq(
 		organization := "com.websudos",
-    version := "0.7.0",
-    scalaVersion := "2.11.5",
+    version := "0.7.1",
+    scalaVersion := "2.11.6",
 		resolvers ++= Seq(
 		"Sonatype repo"                    at "https://oss.sonatype.org/content/groups/scala-tools/",
 		"Sonatype releases"                at "https://oss.sonatype.org/content/repositories/releases",

--- a/project/UtilBuild.scala
+++ b/project/UtilBuild.scala
@@ -35,13 +35,13 @@ object UtilBuild extends Build {
   val NettyVersion = "3.9.0.Final"
 	val ScalaTestVersion = "2.2.0-M1"
   val FinagleVersion = "6.24.0"
-  val LiftVersion = "2.6-M4"
+  val LiftVersion = "3.0-M1"
   val ScalazVersion = "7.1.0"
   val JodaTimeVersion = "2.3"
 
   def liftVersion(scalaVersion: String) = {
     (scalaVersion match {
-      case "2.10.4" => "net.liftweb" % "lift-webkit_2.10" % LiftVersion
+      case "2.10.5" => "net.liftweb" % "lift-webkit_2.10" % LiftVersion
       case _ => "net.liftweb" % "lift-webkit_2.11" % "3.0-M2"
     }) % "compile"
   }
@@ -50,7 +50,6 @@ object UtilBuild extends Build {
 
   val mvnpublishSettings : Seq[Def.Setting[_]] = Seq(
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
-    crossScalaVersions := Seq("2.10.5", "2.11.5"),
     publishTo <<= version { (v: String) => {
       if (v.trim.endsWith("SNAPSHOT"))
         Some("snapshots" at publishUrl + "/ext-snapshot-local")
@@ -100,8 +99,9 @@ object UtilBuild extends Build {
 
   val sharedSettings: Seq[Def.Setting[_]] = Seq(
 		organization := "com.websudos",
-    version := "0.7.1",
+    version := "0.7.5",
     scalaVersion := "2.11.6",
+    crossScalaVersions := Seq("2.10.5", "2.11.6"),
 		resolvers ++= Seq(
 		"Sonatype repo"                    at "https://oss.sonatype.org/content/groups/scala-tools/",
 		"Sonatype releases"                at "https://oss.sonatype.org/content/repositories/releases",

--- a/util-aws/src/main/scala/com/websudos/util/aws/AwsMetadata.scala
+++ b/util-aws/src/main/scala/com/websudos/util/aws/AwsMetadata.scala
@@ -31,15 +31,12 @@ package com.websudos.util.aws
 
 import java.net.InetSocketAddress
 
-import scala.annotation.switch
-
-import org.jboss.netty.handler.codec.http.HttpResponseStatus
-
 import com.twitter.conversions.time._
 import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.finagle.http.{Http, RequestBuilder}
 import com.twitter.util.Future
 import com.websudos.util.http._
+import org.jboss.netty.handler.codec.http.HttpResponseStatus
 
 
 object AwsMetadata {
@@ -67,9 +64,10 @@ object AwsMetadata {
 
     client(req) map  {
       response => {
-        (response.getStatus: @switch) match {
-          case HttpResponseStatus.OK => Some(response.body)
-          case _ => None
+        if (response.getStatus == HttpResponseStatus.OK) {
+          Some(response.body)
+        } else {
+          None
         }
       }
     }

--- a/util-lift/src/main/scala/com/websudos/util/lift/JsonErrorResponse.scala
+++ b/util-lift/src/main/scala/com/websudos/util/lift/JsonErrorResponse.scala
@@ -41,7 +41,7 @@ case class JsonErrorResponse(
   headers: List[(String, String)],
   cookies: List[HTTPCookie] = Nil) {
   def toResponse = {
-    val bytes = json.toJsCmd.getBytes("UTF-8")
+    val bytes = json.toJsCmd.getBytes()
     InMemoryResponse(bytes, ("Content-Length", bytes.length.toString) :: ("Content-Type", "application/json; charset=utf-8") :: headers, cookies, 401)
   }
 }

--- a/util-lift/src/main/scala/com/websudos/util/lift/package.scala
+++ b/util-lift/src/main/scala/com/websudos/util/lift/package.scala
@@ -35,6 +35,7 @@ import net.liftweb.json._
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
+import scalaz.syntax.ApplicativeBuilder
 import scalaz.{NonEmptyList, ValidationNel}
 
 package object lift extends LiftParsers with JsonHelpers {
@@ -118,5 +119,4 @@ package object lift extends LiftParsers with JsonHelpers {
       eval.fold(_.toJson().toFuture(), pf)
     }
   }
-
 }

--- a/util-lift/src/main/scala/com/websudos/util/lift/package.scala
+++ b/util-lift/src/main/scala/com/websudos/util/lift/package.scala
@@ -35,7 +35,6 @@ import net.liftweb.json._
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
-import scalaz.syntax.ApplicativeBuilder
 import scalaz.{NonEmptyList, ValidationNel}
 
 package object lift extends LiftParsers with JsonHelpers {

--- a/util-parsers/src/main/scala/com/websudos/util/parsers/DefaultParsers.scala
+++ b/util-parsers/src/main/scala/com/websudos/util/parsers/DefaultParsers.scala
@@ -69,6 +69,24 @@ trait DefaultParsers {
     parseRequired(str)(uuid)
   }
 
+  final def booleanOpt(str: String): Option[Boolean] = {
+    str match {
+      case "true" => Some(true)
+      case "false" => Some(false)
+      case _ => None
+    }
+  }
+
+
+  final def boolean(str: String): ValidationNel[String, Boolean] = {
+    booleanOpt(str)
+      .fold(s"Couldn't parse boolean from value $str".failureNel[Boolean])(_.successNel[String])
+  }
+
+  final def boolean(str: Option[String]): ValidationNel[String, DateTime] = {
+    parseRequired(str)(_ => boolean(str))
+  }
+
   final def timestampOpt(str: String): Option[DateTime] = {
     Try(new DateTime(str.toLong)).toOption
   }
@@ -183,7 +201,6 @@ trait DefaultParsers {
       first.successNel[String]
     }
   }
-
 
   final def enumOpt[T <: Enumeration](obj: String, enum: T): ValidationNel[String, T#Value] = {
     Try(enum.withName(obj)).toOption

--- a/util-testing/src/main/scala/com/websudos/util/testing/package.scala
+++ b/util-testing/src/main/scala/com/websudos/util/testing/package.scala
@@ -30,21 +30,13 @@
 package com.websudos.util
 
 import com.twitter.util.{Await, Future, Return, Throw}
-import org.scalacheck.Arbitrary
 import org.scalatest.Assertions
 import org.scalatest.concurrent.{AsyncAssertions, PatienceConfiguration, ScalaFutures}
 
-import scala.concurrent.duration._
 import scala.concurrent.{Await => ScalaAwait, ExecutionContext, Future => ScalaFuture}
 import scala.util.{Failure, Success}
 
 package object testing extends ScalaFutures with DefaultTags with DefaultSamplers with ScalaTestHelpers {
-  /**
-   * The default timeout of the asynchronous assertions.
-   * To override this, simply define another implicit timeout in the desired scope.
-   */
-  implicit val s: PatienceConfiguration.Timeout = timeout(1 second)
-
 
   implicit class ScalaBlockHelper[T](val future: ScalaFuture[T]) extends AnyVal {
     def block(duration: scala.concurrent.duration.Duration)(implicit ec: ExecutionContext): T = {
@@ -170,13 +162,4 @@ package object testing extends ScalaFutures with DefaultTags with DefaultSampler
       w.await(timeout, dismissals(1))
     }
   }
-
-
-  implicit def sampleToArbitrary[T](gen: Sample[T]): Arbitrary[T] = Arbitrary(gen.sample)
-
-  implicit def arbitraryToSample[T](arbitrary: Arbitrary[T]): Sample[T] = new Sample[T] {
-    override def sample: T = arbitrary.arbitrary.sample.get
-  }
-
-
 }

--- a/util-testing/src/test/scala/com/websudos/util/testing/GeneratorsTest.scala
+++ b/util-testing/src/test/scala/com/websudos/util/testing/GeneratorsTest.scala
@@ -1,0 +1,23 @@
+package com.websudos.util.testing
+
+import org.scalatest.FlatSpec
+
+class GeneratorsTest extends FlatSpec {
+
+  it should "generate a sized list based on the given argument" in {
+    val limit = 10
+    assert(genList[String](limit).size == limit)
+  }
+
+  it should "generate a sized map based on the given size argument" in {
+    val limit = 10
+
+    assert(genMap[String](limit).size == limit)
+  }
+
+  it should "generate a sized map of known key and value types" in {
+    val limit = 10
+
+    assert(genMap[Int, Int](limit).size == limit)
+  }
+}

--- a/util-zookeeper/src/test/scala/com/websudos/util/zookeeper/ZooKeeperConfTest.scala
+++ b/util-zookeeper/src/test/scala/com/websudos/util/zookeeper/ZooKeeperConfTest.scala
@@ -30,13 +30,20 @@
 package com.websudos.util.zookeeper
 
 import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
 
 import com.twitter.util.RandomSocket
+import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.{BeforeAndAfterAll, Matchers, FlatSpec}
 import com.twitter.conversions.time._
 import com.websudos.util.testing._
 
+import scala.concurrent.duration.Duration
+
 class ZooKeeperConfTest extends FlatSpec with Matchers with BeforeAndAfterAll {
+
+
+  implicit val patience: PatienceConfiguration.Timeout = timeout(Duration(3L, TimeUnit.SECONDS))
 
   val testPath = "/" + gen[String]
   val instance = new ZooKeeperInstance(testPath)

--- a/util-zookeeper/src/test/scala/com/websudos/util/zookeeper/ZooKeeperInstanceTest.scala
+++ b/util-zookeeper/src/test/scala/com/websudos/util/zookeeper/ZooKeeperInstanceTest.scala
@@ -30,12 +30,19 @@
 package com.websudos.util.zookeeper
 
 import java.net.{InetAddress, InetSocketAddress}
+import java.util.concurrent.TimeUnit
 
+import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.{BeforeAndAfterAll, Matchers, FlatSpec}
 import com.websudos.util.testing._
 
+import scala.concurrent.duration.Duration
+
 
 class ZooKeeperInstanceTest extends FlatSpec with Matchers with BeforeAndAfterAll {
+
+  implicit val patience: PatienceConfiguration.Timeout = timeout(Duration(3L, TimeUnit.SECONDS))
+
   val path = "/" + gen[String]
   val instance = new ZooKeeperInstance(path)
 


### PR DESCRIPTION
- Reverted back to ```ZooKeeperServerSetCluster``` implementation in ZooKeeper instance.
- Added tests for list and map generators and overloaded ```genMap``` to support ```genMap[K, V]``` sampling and producer based sampling.
- Fixed generation size issue in list generators.