### PR TITLE
Release/0.8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,4 @@ cache:
 before_script: travis_retry sbt ++$TRAVIS_SCALA_VERSION update
 
 script:
-  - sbt clean coverage test &&
-    sbt coverageAggregate
-
-after_success:
-  - sbt coveralls
+  - sbt test

--- a/project/UtilBuild.scala
+++ b/project/UtilBuild.scala
@@ -33,7 +33,6 @@ import com.twitter.sbt._
 
 object UtilBuild extends Build {
 
-  val NettyVersion = "3.9.0.Final"
 	val ScalaTestVersion = "2.2.4"
   val FinagleVersion = "6.25.0"
   val FinagleZkVersion = "6.24.0"
@@ -89,7 +88,7 @@ object UtilBuild extends Build {
 
   val sharedSettings: Seq[Def.Setting[_]] = Seq(
 		organization := "com.websudos",
-    version := "0.8.0",
+    version := "0.8.8",
     scalaVersion := "2.11.6",
     crossScalaVersions := Seq("2.10.5", "2.11.6"),
 		resolvers ++= Seq(
@@ -149,8 +148,7 @@ object UtilBuild extends Build {
   ).settings(
     name := "util-http",
     libraryDependencies ++= Seq(
-      "com.twitter"             %% "finagle-http"                   % FinagleVersion,
-      "io.netty"                % "netty"                           % NettyVersion
+      "com.twitter"             %% "finagle-http"                   % FinagleVersion
     )
   )
 
@@ -205,7 +203,7 @@ object UtilBuild extends Build {
   ).settings(
     name := "util-zookeeper",
     libraryDependencies ++= Seq(
-      "com.twitter"                      %% "finagle-zookeeper"        % FinagleZkVersion,
+      "com.twitter"                     %% "finagle-zookeeper"        % FinagleZkVersion,
       "com.twitter"                      %% "finagle-serversets"       % FinagleVersion
     )
   ).dependsOn(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,10 +10,6 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.4")
-
-addSbtPlugin("org.scoverage" %% "sbt-coveralls" % "1.0.0.BETA1")
-
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 addSbtPlugin("com.websudos" %% "sbt-package-dist" % "1.2.0")

--- a/util-lift/src/main/scala/com/websudos/util/lift/LiftParsers.scala
+++ b/util-lift/src/main/scala/com/websudos/util/lift/LiftParsers.scala
@@ -42,7 +42,7 @@ trait LiftParsers extends DefaultParsers {
 
   implicit val formats = DefaultFormats
 
-  final def json[T : Manifest](str: String): ValidationNel[String, T] = {
+  final def json[T](str: String)(implicit mf: Manifest[T], formats: Formats): ValidationNel[String, T] = {
     try {
       JsonParser.parse(str).extract[T].successNel[String]
     } catch {
@@ -50,7 +50,7 @@ trait LiftParsers extends DefaultParsers {
     }
   }
 
-  final def json[T: Manifest](str: Option[String]): ValidationNel[String, T] = {
+  final def json[T](str: Option[String])(implicit mf: Manifest[T], formats: Formats): ValidationNel[String, T] = {
     try {
       str.map(JsonParser.parse(_).extract[T].successNel[String]).getOrElse("Missing required parameter".failureNel[T])
     } catch {
@@ -59,12 +59,16 @@ trait LiftParsers extends DefaultParsers {
   }
 
 
-  final def json[T : Manifest](str: JValue): ValidationNel[String, T] = {
+  final def json[T](str: JValue)(implicit mf: Manifest[T], formats: Formats): ValidationNel[String, T] = {
     try {
       str.extract[T].successNel[String]
     } catch {
       case NonFatal(e) => e.getMessage.failureNel[T]
     }
+  }
+
+  final def jsonOpt[T](str: JValue)(implicit mf: Manifest[T], formats: Formats): Option[T] = {
+    str.extractOpt[T]
   }
 
   final def required[T](box: Box[T]): ValidationNel[String, T] = {

--- a/util-lift/src/main/scala/com/websudos/util/lift/Serializers.scala
+++ b/util-lift/src/main/scala/com/websudos/util/lift/Serializers.scala
@@ -1,0 +1,35 @@
+package com.websudos.util.lift
+
+import java.util.UUID
+import scala.util.control.NonFatal
+
+import net.liftweb.json.JsonAST.{JString, JValue}
+import net.liftweb.json._
+
+sealed class UUIDSerializer extends Serializer[UUID] {
+  private val Class = classOf[UUID]
+
+  def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), UUID] = {
+    case (TypeInfo(Class, _), json) => json match {
+      case JString(value) => try {
+        UUID.fromString(value)
+      }  catch {
+        case NonFatal(err) => {
+          val exception =  new MappingException(s"Couldn't extract an UUID from $value")
+          exception.initCause(err)
+          throw exception
+        }
+      }
+      case x => throw new MappingException("Can't convert " + x + " to UUID")
+    }
+  }
+
+  def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
+    case x: UUID => JString(x.toString)
+  }
+}
+
+
+trait CustomSerializers {
+  implicit val formats = Serialization.formats(NoTypeHints) + new UUIDSerializer
+}

--- a/util-lift/src/main/scala/com/websudos/util/lift/package.scala
+++ b/util-lift/src/main/scala/com/websudos/util/lift/package.scala
@@ -65,6 +65,10 @@ package object lift extends LiftParsers with JsonHelpers {
     def asJValue()(implicit formats: Formats, manifest: Manifest[T]): JValue = {
       Extraction.decompose(clz)
     }
+
+    def asResponse()(implicit mf: Manifest[T], formats: DefaultFormats): LiftResponse = {
+      JsonResponse(clz.asJValue(), 200)
+    }
   }
 
   implicit class JsonSeqHelper[T <: Product with Serializable](val list: Seq[T]) extends AnyVal {
@@ -75,6 +79,14 @@ package object lift extends LiftParsers with JsonHelpers {
     def asJValue()(implicit formats: Formats, manifest: Manifest[T]): JValue = {
       Extraction.decompose(list)
     }
+
+    def asResponse()(implicit mf: Manifest[T], formats: DefaultFormats): LiftResponse = {
+      if (list.nonEmpty) {
+        JsonResponse(list.asJValue(), 200)
+      } else {
+        JsonResponse(JArray(Nil), 204)
+      }
+    }
   }
 
   implicit class JsonListHelper[T <: Product with Serializable](val list: List[T]) extends AnyVal {
@@ -84,6 +96,13 @@ package object lift extends LiftParsers with JsonHelpers {
 
     def asJValue()(implicit formats: Formats, manifest: Manifest[T]): JValue = {
       Extraction.decompose(list)
+    }
+
+    def asResponse()(implicit mf: Manifest[T], formats: DefaultFormats): LiftResponse = {
+      list match {
+        case head :: tail => JsonResponse(list.asJValue(), 200)
+        case Nil => JsonResponse(JArray(Nil), 204)
+      }
     }
   }
 

--- a/util-lift/src/test/scala/com/websudos/util/lift/JsonResponseHelpersTest.scala
+++ b/util-lift/src/test/scala/com/websudos/util/lift/JsonResponseHelpersTest.scala
@@ -1,0 +1,23 @@
+package com.websudos.util.lift
+
+import com.websudos.util.testing._
+
+
+class JsonResponseHelpersTest extends LiftTest {
+
+  it should "create a 204 response from an empty product list" in {
+    val list = List.empty[Product with Serializable]
+
+    shouldNotThrow {
+      list.asResponse().toResponse.code shouldEqual 204
+    }
+  }
+
+  it should "create a 200 response from a valid non-empty product list" in {
+    val list = genList[TestClass]()
+
+    shouldNotThrow {
+      list.asResponse().toResponse.code shouldEqual 200
+    }
+  }
+}

--- a/util-lift/src/test/scala/com/websudos/util/lift/LiftTest.scala
+++ b/util-lift/src/test/scala/com/websudos/util/lift/LiftTest.scala
@@ -1,0 +1,18 @@
+package com.websudos.util.lift
+
+import org.scalatest.{Matchers, FlatSpec}
+import com.websudos.util.testing._
+
+class LiftTest extends FlatSpec with Matchers {
+
+  case class TestClass(name: String)
+
+
+  implicit object TestClassSampler extends Sample[TestClass] {
+    def sample: TestClass = {
+      TestClass(
+        gen[String]
+      )
+    }
+  }
+}

--- a/util-parsers/src/main/scala/com/websudos/util/parsers/DefaultParsers.scala
+++ b/util-parsers/src/main/scala/com/websudos/util/parsers/DefaultParsers.scala
@@ -202,14 +202,13 @@ trait DefaultParsers {
     }
   }
 
-  final def enumOpt[T <: Enumeration](obj: String, enum: T): ValidationNel[String, T#Value] = {
+  final def enumOpt[T <: Enumeration](obj: String, enum: T): Option[T#Value] = {
     Try(enum.withName(obj)).toOption
-      .fold(s"Value $obj is not part of the enumeration".failureNel[T#Value])(item => item.successNel[String])
   }
 
   final def enum[T <: Enumeration](obj: String, enum: T): ValidationNel[String, T#Value] = {
     enumOpt(obj, enum)
-      .fold(_ => s"Value $obj is not part of the enumeration".failureNel[T#Value], _.successNel[String])
+      .fold(s"Value $obj is not part of the enumeration".failureNel[T#Value])(_.successNel[String])
   }
 
 }

--- a/util-parsers/src/main/scala/com/websudos/util/parsers/package.scala
+++ b/util-parsers/src/main/scala/com/websudos/util/parsers/package.scala
@@ -29,4 +29,5 @@
  */
 package com.websudos.util
 
-package object parsers extends DefaultParsers {}
+package object parsers extends DefaultParsers
+

--- a/util-parsers/src/test/scala/com/websudos/util/parsers/DefaultParsersTest.scala
+++ b/util-parsers/src/test/scala/com/websudos/util/parsers/DefaultParsersTest.scala
@@ -29,8 +29,37 @@
  */
 package com.websudos.util.parsers
 
-import org.scalatest.FlatSpec
+import org.scalatest.{Matchers, FlatSpec}
 
-class DefaultParsers extends FlatSpec {
+class DefaultParsersTest extends FlatSpec with Matchers {
 
+  it should "parse a long as an applicative from a valid string" in {
+    val parser = long("124")
+    parser.isSuccess shouldEqual true
+
+    parser.toOption.isDefined shouldEqual true
+    parser.toOption.get shouldEqual 124L
+  }
+
+  it should "parse a long as an option from a valid string" in {
+    val parser = longOpt("124")
+
+    parser.isDefined shouldEqual true
+    parser.get shouldEqual 124L
+  }
+
+  it should "parse a long as an applicative from an optional string" in {
+    val parser = long(Some("124"))
+    parser.isSuccess shouldEqual true
+
+    parser.toOption.isDefined shouldEqual true
+    parser.toOption.get shouldEqual 124L
+  }
+
+  it should "fail parsing an applicative from an empty option" in {
+    val parser = long(None)
+    parser.isSuccess shouldEqual false
+    parser.toOption.isDefined shouldEqual false
+  }
 }
+


### PR DESCRIPTION
- Improving support for Lift response helpers with automated `asResponse` converters for `Product`, `Seq[Product]` and `List[Product]`.
- Removing Websudos resolves in favour of the new Bintray infrastructure.
- Adding tests for parsers and response converters.